### PR TITLE
Event=time type error

### DIFF
--- a/src/components/waveform/index.tsx
+++ b/src/components/waveform/index.tsx
@@ -123,7 +123,7 @@ export default function WaveForm() {
   };
 
   //Adds a new segment to the zoomview on double clicked
-  const handleZoomviewDblClick = (event: WaveformViewMouseEvent) => {
+  const handleZoomviewDblClick = () => {
     clickToAddSegment(segments, setSegments, myPeaks!);
   };
   //////////////////////////////////////////////////////////////////////

--- a/src/components/waveform/index.tsx
+++ b/src/components/waveform/index.tsx
@@ -124,7 +124,7 @@ export default function WaveForm() {
 
   //Adds a new segment to the zoomview on double clicked
   const handleZoomviewDblClick = (event: WaveformViewMouseEvent) => {
-    clickToAddSegment(segments, setSegments, myPeaks!, event);
+    clickToAddSegment(segments, setSegments, myPeaks!);
   };
   //////////////////////////////////////////////////////////////////////
 

--- a/src/lib/waveform-utils.ts
+++ b/src/lib/waveform-utils.ts
@@ -193,10 +193,8 @@ export const handleAddSegment = (
 export const clickToAddSegment = (
   segments: TestSegmentProps[],
   setSegments: React.Dispatch<React.SetStateAction<TestSegmentProps[]>>,
-  myPeaks: PeaksInstance,
-  event: WaveformViewMouseEvent
+  myPeaks: PeaksInstance
 ) => {
-  // console.log("inside clickToAddSegment", event);
   //create playhead and upper and lower boundaries based on playhead position
   const playheadPosition = myPeaks.player.getCurrentTime();
   const segUpperBound = playheadPosition + 8;

--- a/src/lib/waveform-utils.ts
+++ b/src/lib/waveform-utils.ts
@@ -196,9 +196,9 @@ export const clickToAddSegment = (
   myPeaks: PeaksInstance,
   event: WaveformViewMouseEvent
 ) => {
-  console.log("inside clickToAddSegment", event);
+  // console.log("inside clickToAddSegment", event);
   //create playhead and upper and lower boundaries based on playhead position
-  const playheadPosition = event.time;
+  const playheadPosition = myPeaks.player.getCurrentTime();
   const segUpperBound = playheadPosition + 8;
   const segLowerBound = playheadPosition;
   const mediaEndTime = myPeaks.player.getDuration();


### PR DESCRIPTION
replaced `const playheadPosition = event.time;` with `const playheadPosition = myPeaks.player.getCurrentTime();`

This method is available on the peaks instance and returns the current playhead time

The event argument is no longer needed at all in clickToAddSegment() so i removed it