### PR TITLE
Invalid playhead modal

### DIFF
--- a/src/components/waveform/index.tsx
+++ b/src/components/waveform/index.tsx
@@ -140,7 +140,6 @@ export default function WaveForm() {
 
   //Adds a new segment to the zoomview on double clicked
   const handleZoomviewDblClick = () => {
-    console.log("handleZoomviewDblClick", { isOpen });
     handleAddSegment(segments, setSegments, myPeaks!, onOpen, setClipOverlap);
   };
   //////////////////////////////////////////////////////////////////////

--- a/src/components/waveform/index.tsx
+++ b/src/components/waveform/index.tsx
@@ -1,4 +1,16 @@
-import { Flex, Button } from "@chakra-ui/react";
+import {
+  Flex,
+  Button,
+  useDisclosure,
+  Modal,
+  ModalOverlay,
+  ModalContent,
+  ModalHeader,
+  ModalFooter,
+  ModalBody,
+  ModalCloseButton,
+  Text,
+} from "@chakra-ui/react";
 import React, { useCallback, useEffect, useState } from "react";
 import { OverviewContainer, ZoomviewContainer } from "./styled";
 import Peaks, { PeaksInstance, PeaksOptions, SegmentDragEvent } from "peaks.js";
@@ -21,6 +33,8 @@ import {
 import ClipGridHeader from "./components/ClipGridHeader";
 
 export default function WaveForm() {
+  const { isOpen, onClose, onOpen } = useDisclosure();
+
   //////////////////////////////////////////////////////////////////////
   //
   //
@@ -125,7 +139,8 @@ export default function WaveForm() {
 
   //Adds a new segment to the zoomview on double clicked
   const handleZoomviewDblClick = () => {
-    handleAddSegment(segments, setSegments, myPeaks!);
+    console.log("handleZoomviewDblClick", { isOpen });
+    handleAddSegment(segments, setSegments, myPeaks!, onOpen);
   };
   //////////////////////////////////////////////////////////////////////
 
@@ -160,6 +175,23 @@ export default function WaveForm() {
 
   return (
     <>
+      <Modal isOpen={isOpen} onClose={onClose}>
+        <ModalOverlay />
+        <ModalContent>
+          <ModalHeader>Modal Title</ModalHeader>
+          <ModalCloseButton />
+          <ModalBody>
+            <Text textStyle={"context"}>Invalid playhead position</Text>
+          </ModalBody>
+
+          <ModalFooter>
+            <Button colorScheme="blue" mr={3} onClick={onClose}>
+              Close
+            </Button>
+            <Button variant="ghost">Secondary Action</Button>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
       <Flex
         justify={"center"}
         align={"center"}
@@ -180,7 +212,9 @@ export default function WaveForm() {
         <Flex>
           <Button
             variant={"waveformBlue"}
-            onClick={() => handleAddSegment(segments, setSegments, myPeaks!)}
+            onClick={() =>
+              handleAddSegment(segments, setSegments, myPeaks!, onOpen)
+            }
           >
             Add Segment
           </Button>

--- a/src/components/waveform/index.tsx
+++ b/src/components/waveform/index.tsx
@@ -173,22 +173,28 @@ export default function WaveForm() {
     };
   }, [myPeaks, handleClipDragEnd, handleZoomviewDblClick]);
 
+  const overlap = true;
   return (
     <>
       <Modal isOpen={isOpen} onClose={onClose}>
         <ModalOverlay />
         <ModalContent>
-          <ModalHeader>Modal Title</ModalHeader>
+          <ModalHeader>Unable to Add Segment</ModalHeader>
           <ModalCloseButton />
           <ModalBody>
-            <Text textStyle={"context"}>Invalid playhead position</Text>
+            <Text textStyle={"smContext"}></Text>
+            {overlap
+              ? `Clips must be greater than ${(
+                  myPeaks?.player.getDuration()! * 0.03
+                ).toFixed(1)} seconds`
+              : "Clips must not overlap"}
+            {/* 'Please choose a gap greater than {(myPeaks?.player.getDuration()! * 0.03).toFixed(1)} seconds */}
           </ModalBody>
 
           <ModalFooter>
-            <Button colorScheme="blue" mr={3} onClick={onClose}>
+            <Button variant={"brandPrimaryMobileNav"} mr={3} onClick={onClose}>
               Close
             </Button>
-            <Button variant="ghost">Secondary Action</Button>
           </ModalFooter>
         </ModalContent>
       </Modal>

--- a/src/components/waveform/index.tsx
+++ b/src/components/waveform/index.tsx
@@ -70,6 +70,7 @@ export default function WaveForm() {
   const [myPeaks, setMyPeaks] = useState<PeaksInstance | undefined>();
   const [segments, setSegments] =
     useState<TestSegmentProps[]>(testSegmentsSmall);
+  const [clipOverlap, setClipOverlap] = useState<boolean>(false);
 
   // create function to create instance of peaks
   // useCallback means this will only render a single instance of peaks
@@ -140,7 +141,7 @@ export default function WaveForm() {
   //Adds a new segment to the zoomview on double clicked
   const handleZoomviewDblClick = () => {
     console.log("handleZoomviewDblClick", { isOpen });
-    handleAddSegment(segments, setSegments, myPeaks!, onOpen);
+    handleAddSegment(segments, setSegments, myPeaks!, onOpen, setClipOverlap);
   };
   //////////////////////////////////////////////////////////////////////
 
@@ -173,7 +174,6 @@ export default function WaveForm() {
     };
   }, [myPeaks, handleClipDragEnd, handleZoomviewDblClick]);
 
-  const overlap = true;
   return (
     <>
       <Modal isOpen={isOpen} onClose={onClose}>
@@ -183,12 +183,11 @@ export default function WaveForm() {
           <ModalCloseButton />
           <ModalBody>
             <Text textStyle={"smContext"}></Text>
-            {overlap
-              ? `Clips must be greater than ${(
+            {clipOverlap
+              ? `There is not enough room for your clip. Please choose a gap larger than ${(
                   myPeaks?.player.getDuration()! * 0.03
                 ).toFixed(1)} seconds`
-              : "Clips must not overlap"}
-            {/* 'Please choose a gap greater than {(myPeaks?.player.getDuration()! * 0.03).toFixed(1)} seconds */}
+              : "A clip already exists at that position, clips cannot overlap. Please choose an empty gap on the timeline"}
           </ModalBody>
 
           <ModalFooter>
@@ -219,7 +218,13 @@ export default function WaveForm() {
           <Button
             variant={"waveformBlue"}
             onClick={() =>
-              handleAddSegment(segments, setSegments, myPeaks!, onOpen)
+              handleAddSegment(
+                segments,
+                setSegments,
+                myPeaks!,
+                onOpen,
+                setClipOverlap
+              )
             }
           >
             Add Segment

--- a/src/lib/waveform-utils.ts
+++ b/src/lib/waveform-utils.ts
@@ -226,7 +226,6 @@ export const handleAddSegment = (
     //move the playhead to the start of the new segment
     myPeaks.player.seek(newSegment.startTime);
   } else {
-    console.log({ invalidPlayheadPosition, validGapLength });
     invalidPlayheadPosition ? setClipOverlap(false) : setClipOverlap(true);
     onOpen();
   }

--- a/src/lib/waveform-utils.ts
+++ b/src/lib/waveform-utils.ts
@@ -72,7 +72,8 @@ export const handleAddSegment = (
   segments: TestSegmentProps[],
   setSegments: React.Dispatch<React.SetStateAction<TestSegmentProps[]>>,
   myPeaks: PeaksInstance,
-  onOpen: () => void
+  onOpen: () => void,
+  setClipOverlap: React.Dispatch<React.SetStateAction<boolean>>
 ) => {
   const firstClip = segments.length === 0;
   const secondClip = segments.length === 1;
@@ -194,6 +195,8 @@ export const handleAddSegment = (
     //move the playhead to the start of the new segment
     myPeaks.player.seek(newSegment.startTime);
   } else {
+    console.log({ invalidPlayheadPosition, validGapLength });
+    invalidPlayheadPosition ? setClipOverlap(false) : setClipOverlap(true);
     onOpen();
   }
 };

--- a/src/lib/waveform-utils.ts
+++ b/src/lib/waveform-utils.ts
@@ -71,7 +71,8 @@ export const editClipStartEndPoints = (
 export const handleAddSegment = (
   segments: TestSegmentProps[],
   setSegments: React.Dispatch<React.SetStateAction<TestSegmentProps[]>>,
-  myPeaks: PeaksInstance
+  myPeaks: PeaksInstance,
+  onOpen: () => void
 ) => {
   const firstClip = segments.length === 0;
   const secondClip = segments.length === 1;
@@ -193,7 +194,7 @@ export const handleAddSegment = (
     //move the playhead to the start of the new segment
     myPeaks.player.seek(newSegment.startTime);
   } else {
-    alert("Invalid playhead position");
+    onOpen();
   }
 };
 //////////////////////////////////////////////////////////////////////

--- a/src/lib/waveform-utils.ts
+++ b/src/lib/waveform-utils.ts
@@ -166,6 +166,37 @@ export const handleAddSegment = (
     //move the playhead to the start of the new segment
     myPeaks.player.seek(newSegment.startTime);
   } else if (
+    secondClip &&
+    !invalidPlayheadPosition &&
+    playheadPosition < segments[0].startTime
+  ) {
+    //swapping Top and tail clips if second clip added is before original Top clip
+    segments[0].fileName = "Tail";
+    segments[0].labelText = "Tail";
+
+    const newSegment = {
+      id: segments.length.toString(),
+      fileName: "Top",
+      startTime: playheadPosition,
+      endTime: playheadPosition + mediaLength * 0.03,
+      editable: true,
+      color: "#1E1541",
+      labelText: "Top",
+      formErrors: {
+        fileNameError: false,
+        startTimeError: false,
+        endTimeError: false,
+        isCreated: false,
+      },
+    };
+
+    //add new segment to the segments array, sort it by start time and update segments state
+    const updatedSegments = [...segments, newSegment];
+    setSegments(updatedSegments.sort((a, b) => a.startTime - b.startTime));
+
+    //move the playhead to the start of the new segment
+    myPeaks.player.seek(newSegment.startTime);
+  } else if (
     !invalidPlayheadPosition &&
     validGapLength !== -1
     // playheadPosition > segments[0].startTime &&
@@ -188,7 +219,7 @@ export const handleAddSegment = (
       },
     };
 
-    //add new segment to the segments array, sort it by sart time and update segments state
+    //add new segment to the segments array, sort it by start time and update segments state
     const updatedSegments = [...segments, newSegment];
     setSegments(updatedSegments.sort((a, b) => a.startTime - b.startTime));
 


### PR DESCRIPTION
Modal conditonally renders two messages for errors when adding a clip
if the playhead position is overlapping another clip
or if there isnt enough room in the gap for the clip

If the second 'tail' clip is placed before the top, the clip names are swapped.