### PR TITLE
Edit clip error checking

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -24,7 +24,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>React App</title>
+    <title>EOS Waveform Prototype</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/src/lib/waveform-utils.ts
+++ b/src/lib/waveform-utils.ts
@@ -37,11 +37,39 @@ export const editClipStartEndPoints = (
   segments: TestSegmentProps[],
   setSegments: React.Dispatch<React.SetStateAction<TestSegmentProps[]>>
 ) => {
+  //id for the current clip being edited
+  const segmentId = evt.segment.id;
+
+  //function to return true if the timecode is between the start and end of a clip
+  const timecodeIsBetweenClip = (
+    timecode: number,
+    start: number,
+    end: number
+  ) => {
+    return (timecode - start) * (timecode - end) <= 0;
+  };
+
+  //map over the segments array, except for current clip index and call timecodeIsBetweenClip
+  //returns true if any element contains the timecode for the new start time
+  const invalidStartTimePositions = segments
+    .map((seg) => {
+      if (seg.id !== segmentId)
+        return timecodeIsBetweenClip(
+          evt.segment.startTime,
+          seg.startTime,
+          seg.endTime
+        );
+      return seg;
+    })
+    .includes(true);
+
   const newSegState = segments.map((seg) => {
     if (seg.id === evt.segment.id && evt.startMarker) {
       return {
         ...seg,
-        startTime: evt.segment.startTime,
+        startTime: invalidStartTimePositions
+          ? seg.startTime
+          : evt.segment.startTime,
       };
     } else if (seg.id === evt.segment.id && !evt.startMarker) {
       return {
@@ -275,77 +303,6 @@ export const handleFileNameChange = (
 
 //////////////////////////////////////////////////////////////////////
 //
-//             handles start time error checking
-//
-//             start time needs to be greater than previous segments end time
-//
-//             !!This needs some more work!!
-//
-//
-// export const handleStartTimeChange = (
-//   id: string,
-//   evt: ChangeEvent<HTMLInputElement>,
-//   segments: TestSegmentProps[],
-//   setSegments: React.Dispatch<React.SetStateAction<TestSegmentProps[]>>
-// ) => {
-//   //used for two way bind of start time input element to correct segment in segments
-//   const newSegState = segments.map((seg) => {
-//     if (seg.id === id) {
-//       return {
-//         ...seg,
-//         startTime:
-//           parseInt(evt.target.value) < seg.endTime!
-//             ? parseInt(evt.target.value)
-//             : 0,
-//       };
-//     }
-//     //otherwise return the segment unchanged
-//     return seg;
-//   });
-//   //use the updated segment to update the segments state
-//   setSegments(newSegState);
-// };
-//////////////////////////////////////////////////////////////////////
-
-//////////////////////////////////////////////////////////////////////
-//
-//             handles end time error checking
-//
-//             end time needs to be less than next segments start time
-//
-//             !!This needs some more work!!
-//
-//
-// export const handleEndTimeChange = (
-//   id: string,
-//   evt: ChangeEvent<HTMLInputElement>,
-//   segments: TestSegmentProps[],
-//   setSegments: React.Dispatch<React.SetStateAction<TestSegmentProps[]>>,
-//   myPeaks: PeaksInstance
-// ) => {
-//   //used for two way bind of end time input element to correct segment in segments
-//   const newSegState = segments.map((seg, idx: number) => {
-//     if (seg.id === id) {
-//       return {
-//         ...seg,
-//         endTime:
-//           parseInt(evt.target.value) > seg.startTime &&
-//           parseInt(evt.target.value) < segments[idx + 1].startTime
-//             ? parseInt(evt.target.value)
-//             : myPeaks.player.getDuration()!,
-//       };
-//     }
-
-//     //otherwise return the segment unchanged
-//     return seg;
-//   });
-//   //use the updated segment to update the segments state
-//   setSegments(newSegState);
-// };
-//////////////////////////////////////////////////////////////////////
-
-//////////////////////////////////////////////////////////////////////
-//
 //             Delete all segments
 //
 //
@@ -455,3 +412,74 @@ export const deleteSingleSegment = (
 //
 //
 //
+
+//////////////////////////////////////////////////////////////////////
+//
+//             handles start time error checking
+//
+//             start time needs to be greater than previous segments end time
+//
+//             !!This needs some more work!!
+//
+//
+// export const handleStartTimeChange = (
+//   id: string,
+//   evt: ChangeEvent<HTMLInputElement>,
+//   segments: TestSegmentProps[],
+//   setSegments: React.Dispatch<React.SetStateAction<TestSegmentProps[]>>
+// ) => {
+//   //used for two way bind of start time input element to correct segment in segments
+//   const newSegState = segments.map((seg) => {
+//     if (seg.id === id) {
+//       return {
+//         ...seg,
+//         startTime:
+//           parseInt(evt.target.value) < seg.endTime!
+//             ? parseInt(evt.target.value)
+//             : 0,
+//       };
+//     }
+//     //otherwise return the segment unchanged
+//     return seg;
+//   });
+//   //use the updated segment to update the segments state
+//   setSegments(newSegState);
+// };
+//////////////////////////////////////////////////////////////////////
+
+//////////////////////////////////////////////////////////////////////
+//
+//             handles end time error checking
+//
+//             end time needs to be less than next segments start time
+//
+//             !!This needs some more work!!
+//
+//
+// export const handleEndTimeChange = (
+//   id: string,
+//   evt: ChangeEvent<HTMLInputElement>,
+//   segments: TestSegmentProps[],
+//   setSegments: React.Dispatch<React.SetStateAction<TestSegmentProps[]>>,
+//   myPeaks: PeaksInstance
+// ) => {
+//   //used for two way bind of end time input element to correct segment in segments
+//   const newSegState = segments.map((seg, idx: number) => {
+//     if (seg.id === id) {
+//       return {
+//         ...seg,
+//         endTime:
+//           parseInt(evt.target.value) > seg.startTime &&
+//           parseInt(evt.target.value) < segments[idx + 1].startTime
+//             ? parseInt(evt.target.value)
+//             : myPeaks.player.getDuration()!,
+//       };
+//     }
+
+//     //otherwise return the segment unchanged
+//     return seg;
+//   });
+//   //use the updated segment to update the segments state
+//   setSegments(newSegState);
+// };
+//////////////////////////////////////////////////////////////////////

--- a/src/lib/waveform-utils.ts
+++ b/src/lib/waveform-utils.ts
@@ -39,6 +39,7 @@ export const editClipStartEndPoints = (
 ) => {
   //id for the current clip being edited
   const segmentId = evt.segment.id;
+  const startMarker = evt.startMarker;
 
   //function to return true if the timecode is between the start and end of a clip
   const timecodeIsBetweenClip = (
@@ -50,7 +51,7 @@ export const editClipStartEndPoints = (
   };
 
   const newSegState = segments.map((seg) => {
-    if (seg.id === segmentId && evt.startMarker) {
+    if (seg.id === segmentId && startMarker) {
       //map over the segments array, except for current clip index and call timecodeIsBetweenClip
       //returns true if any element contains the timecode for the new start time
       const invalidStartTimePositions = segments
@@ -70,7 +71,7 @@ export const editClipStartEndPoints = (
           ? seg.startTime
           : evt.segment.startTime,
       };
-    } else if (seg.id === segmentId && !evt.startMarker) {
+    } else if (seg.id === segmentId && !startMarker) {
       //map over the segments array, except for current clip index and call timecodeIsBetweenClip
       //returns true if any element contains the timecode for the new start time
       const invalidStartTimePositions = segments

--- a/src/lib/waveform-utils.ts
+++ b/src/lib/waveform-utils.ts
@@ -282,29 +282,29 @@ export const handleFileNameChange = (
 //             !!This needs some more work!!
 //
 //
-export const handleStartTimeChange = (
-  id: string,
-  evt: ChangeEvent<HTMLInputElement>,
-  segments: TestSegmentProps[],
-  setSegments: React.Dispatch<React.SetStateAction<TestSegmentProps[]>>
-) => {
-  //used for two way bind of start time input element to correct segment in segments
-  const newSegState = segments.map((seg) => {
-    if (seg.id === id) {
-      return {
-        ...seg,
-        startTime:
-          parseInt(evt.target.value) < seg.endTime!
-            ? parseInt(evt.target.value)
-            : 0,
-      };
-    }
-    //otherwise return the segment unchanged
-    return seg;
-  });
-  //use the updated segment to update the segments state
-  setSegments(newSegState);
-};
+// export const handleStartTimeChange = (
+//   id: string,
+//   evt: ChangeEvent<HTMLInputElement>,
+//   segments: TestSegmentProps[],
+//   setSegments: React.Dispatch<React.SetStateAction<TestSegmentProps[]>>
+// ) => {
+//   //used for two way bind of start time input element to correct segment in segments
+//   const newSegState = segments.map((seg) => {
+//     if (seg.id === id) {
+//       return {
+//         ...seg,
+//         startTime:
+//           parseInt(evt.target.value) < seg.endTime!
+//             ? parseInt(evt.target.value)
+//             : 0,
+//       };
+//     }
+//     //otherwise return the segment unchanged
+//     return seg;
+//   });
+//   //use the updated segment to update the segments state
+//   setSegments(newSegState);
+// };
 //////////////////////////////////////////////////////////////////////
 
 //////////////////////////////////////////////////////////////////////
@@ -316,32 +316,32 @@ export const handleStartTimeChange = (
 //             !!This needs some more work!!
 //
 //
-export const handleEndTimeChange = (
-  id: string,
-  evt: ChangeEvent<HTMLInputElement>,
-  segments: TestSegmentProps[],
-  setSegments: React.Dispatch<React.SetStateAction<TestSegmentProps[]>>,
-  myPeaks: PeaksInstance
-) => {
-  //used for two way bind of end time input element to correct segment in segments
-  const newSegState = segments.map((seg, idx: number) => {
-    if (seg.id === id) {
-      return {
-        ...seg,
-        endTime:
-          parseInt(evt.target.value) > seg.startTime &&
-          parseInt(evt.target.value) < segments[idx + 1].startTime
-            ? parseInt(evt.target.value)
-            : myPeaks.player.getDuration()!,
-      };
-    }
+// export const handleEndTimeChange = (
+//   id: string,
+//   evt: ChangeEvent<HTMLInputElement>,
+//   segments: TestSegmentProps[],
+//   setSegments: React.Dispatch<React.SetStateAction<TestSegmentProps[]>>,
+//   myPeaks: PeaksInstance
+// ) => {
+//   //used for two way bind of end time input element to correct segment in segments
+//   const newSegState = segments.map((seg, idx: number) => {
+//     if (seg.id === id) {
+//       return {
+//         ...seg,
+//         endTime:
+//           parseInt(evt.target.value) > seg.startTime &&
+//           parseInt(evt.target.value) < segments[idx + 1].startTime
+//             ? parseInt(evt.target.value)
+//             : myPeaks.player.getDuration()!,
+//       };
+//     }
 
-    //otherwise return the segment unchanged
-    return seg;
-  });
-  //use the updated segment to update the segments state
-  setSegments(newSegState);
-};
+//     //otherwise return the segment unchanged
+//     return seg;
+//   });
+//   //use the updated segment to update the segments state
+//   setSegments(newSegState);
+// };
 //////////////////////////////////////////////////////////////////////
 
 //////////////////////////////////////////////////////////////////////

--- a/src/lib/waveform-utils.ts
+++ b/src/lib/waveform-utils.ts
@@ -144,6 +144,7 @@ export const handleAddSegment = (
 
   // Check the gaps between segments[1] and segments[n-2] to see if they are
   //large enough to contain the new clip length
+  // eslint-disable-next-line
   const validGapLength = segments.findIndex((seg, idx, arr) => {
     if (idx + 1 < arr.length) {
       return (

--- a/src/lib/waveform-utils.ts
+++ b/src/lib/waveform-utils.ts
@@ -49,22 +49,21 @@ export const editClipStartEndPoints = (
     return (timecode - start) * (timecode - end) <= 0;
   };
 
-  //map over the segments array, except for current clip index and call timecodeIsBetweenClip
-  //returns true if any element contains the timecode for the new start time
-  const invalidStartTimePositions = segments
-    .map((seg) => {
-      if (seg.id !== segmentId)
-        return timecodeIsBetweenClip(
-          evt.segment.startTime,
-          seg.startTime,
-          seg.endTime
-        );
-      return seg;
-    })
-    .includes(true);
-
   const newSegState = segments.map((seg) => {
     if (seg.id === evt.segment.id && evt.startMarker) {
+      //map over the segments array, except for current clip index and call timecodeIsBetweenClip
+      //returns true if any element contains the timecode for the new start time
+      const invalidStartTimePositions = segments
+        .map((seg) => {
+          if (seg.id !== segmentId)
+            return timecodeIsBetweenClip(
+              evt.segment.startTime,
+              seg.startTime,
+              seg.endTime
+            );
+          return seg;
+        })
+        .includes(true);
       return {
         ...seg,
         startTime: invalidStartTimePositions
@@ -72,9 +71,22 @@ export const editClipStartEndPoints = (
           : evt.segment.startTime,
       };
     } else if (seg.id === evt.segment.id && !evt.startMarker) {
+      //map over the segments array, except for current clip index and call timecodeIsBetweenClip
+      //returns true if any element contains the timecode for the new start time
+      const invalidStartTimePositions = segments
+        .map((seg) => {
+          if (seg.id !== segmentId)
+            return timecodeIsBetweenClip(
+              evt.segment.endTime,
+              seg.startTime,
+              seg.endTime
+            );
+          return seg;
+        })
+        .includes(true);
       return {
         ...seg,
-        endTime: evt.segment.endTime,
+        endTime: invalidStartTimePositions ? seg.endTime : evt.segment.endTime,
       };
     }
     // otherwise return the segment unchanged

--- a/src/lib/waveform-utils.ts
+++ b/src/lib/waveform-utils.ts
@@ -50,7 +50,7 @@ export const editClipStartEndPoints = (
   };
 
   const newSegState = segments.map((seg) => {
-    if (seg.id === evt.segment.id && evt.startMarker) {
+    if (seg.id === segmentId && evt.startMarker) {
       //map over the segments array, except for current clip index and call timecodeIsBetweenClip
       //returns true if any element contains the timecode for the new start time
       const invalidStartTimePositions = segments
@@ -70,7 +70,7 @@ export const editClipStartEndPoints = (
           ? seg.startTime
           : evt.segment.startTime,
       };
-    } else if (seg.id === evt.segment.id && !evt.startMarker) {
+    } else if (seg.id === segmentId && !evt.startMarker) {
       //map over the segments array, except for current clip index and call timecodeIsBetweenClip
       //returns true if any element contains the timecode for the new start time
       const invalidStartTimePositions = segments


### PR DESCRIPTION
Clip start or end points will snap back to origin if their new location falls within the start or end time of the adjacent clip
Error checking needs tweaking, if the start time is pulled to a timecode prior to previous clips start time, the new start time is  allowed. Same occurs with the endtime move. may need to split endtime and start time dragging into two functions